### PR TITLE
Added all of the requirements for php7 cli and fpm with a build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,19 @@
 language: bash
 services: docker
-
 env:
-  - VERSION=7.0 VARIANT=
-  - VERSION=7.0 VARIANT=fpm
-
+- VERSION=7.0 VARIANT=
+- VERSION=7.0 VARIANT=fpm
 install:
-  - git clone https://github.com/docker-library/official-images.git ~/official-images
-
+- git clone https://github.com/docker-library/official-images.git ~/official-images
 before_script:
-  - env | sort
-  - cd "$VERSION"
-  - image="realpage/php:${VERSION}${VARIANT:+-$VARIANT}"
-
+- env | sort
+- cd "$VERSION"
+- image="realpage/php:${VERSION}${VARIANT:+-$VARIANT}"
 script:
-  - docker build -t "$image" "${VARIANT:-.}"
-  - ~/official-images/test/run.sh "$image"
-
+- docker build -t "$image" "${VARIANT:-.}"
+- ~/official-images/test/run.sh "$image"
 after_script:
-  - docker images
-
-# vim:set et ts=2 sw=2:
+- docker images
+notifications:
+  slack:
+    secure: ukIO/itKnZkToUMXPo6mXbfEaMB25BNXKDhFLkdGz2vvTl0w6tv5Oc11tjqTrdWwtqv1fbeE+WNC5x7mHc3MV4GjUUGALdCfMiKUQsyz+LKa+mIFcey4iOpj0Q+z6ecTLBVjO90bkV9EvSnoS2uLLW4Bpy6e+Iaecl8Z9XeQwC8+lb4EwJm9ynPTm0GfxfAGmZclOwRHJWTZlCkpRqRAq13UjduIltUejinU9+rPJVF3Q6Z23lEZdU62cvaVSCwhkQIACsQP0qvyNdNwS4bBA09AzYQYzPhYr4d1joeOxTUXKQ1u0Pd6gzQxEPYLnSyqtu3MB7P5PTQsdH5Gj5xiqaPYKnxgXm93NOWH1M6jyfpYzAyvPs0imJ9G05+NUMNnrPOBLlv65PVG3LRoKtG5aEG29cEMQEoFESgf54eI1Ot2u+vWDvU/GygzL3wF1XGSWcVCZXGUsAxUtbN8A+Z/aquZ23fo8w2w/VGhOcA8uI12W3Lsbr7O7nYHLgsIO3b2OhJKG6u1MMwyr2VpfOoK1KdWfsFzgFReqP0WMiCQzRHgwyw//p8mIszoGaFFRqVRHA4nyt0Hf77V7sApj0NVL5WfEDNLR7v1YI1B8SE9YZ+B2IO+tLGYhPOgpR2/oWvoRVtWMLkZhig5tH1qnaXc+cV7k2mzIs2i5YnZJ2A3hpw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: bash
+services: docker
+
+env:
+  - VERSION=7.0 VARIANT=
+  - VERSION=7.0 VARIANT=fpm
+
+install:
+  - git clone https://github.com/docker-library/official-images.git ~/official-images
+
+before_script:
+  - env | sort
+  - cd "$VERSION"
+  - image="realpage/php:${VERSION}${VARIANT:+-$VARIANT}"
+
+script:
+  - docker build -t "$image" "${VARIANT:-.}"
+  - ~/official-images/test/run.sh "$image"
+
+after_script:
+  - docker images
+
+# vim:set et ts=2 sw=2:

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -4,8 +4,6 @@ LABEL version="1.0.0-beta" \
       com.realpage.php.version="7.0.4" \
       com.realpage.php.type="cli"
 
-WORKDIR /var/www
-
 # install extensions
 RUN apt-get update && apt-get install -y libmcrypt-dev libpq5 libpq-dev \
     && docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:7.0.4-cli
+MAINTAINER RealPage DevOps Foundation-Devops@RealPage.com
+LABEL version="1.0.0-beta" \
+	  com.realpage.php.version="7.0.4" \
+	  com.realpage.php.type="fpm"
+
+# install extensions
+RUN apt-get update && apt-get install -y libmcrypt-dev libpq5 libpq-dev \
+	&& docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \
+	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,10 +1,13 @@
 FROM php:7.0.4-cli
 MAINTAINER RealPage DevOps Foundation-Devops@RealPage.com
 LABEL version="1.0.0-beta" \
-	  com.realpage.php.version="7.0.4" \
-	  com.realpage.php.type="fpm"
+      com.realpage.php.version="7.0.4" \
+      com.realpage.php.type="cli"
+
+WORKDIR /var/www
 
 # install extensions
 RUN apt-get update && apt-get install -y libmcrypt-dev libpq5 libpq-dev \
-	&& docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \
-	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && rm -r /var/www/html

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -7,5 +7,4 @@ LABEL version="1.0.0-beta" \
 # install extensions
 RUN apt-get update && apt-get install -y libmcrypt-dev libpq5 libpq-dev \
     && docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && rm -r /var/www/html
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -4,8 +4,6 @@ LABEL version="1.0.0-beta" \
       com.realpage.php.version="7.0.4" \
       com.realpage.php.type="fpm"
 
-WORKDIR /var/www
-
 # install extensions
 RUN apt-get update && apt-get install -y libmcrypt-dev libpq5 libpq-dev \
     && docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -1,10 +1,13 @@
 FROM php:7.0.4-fpm
 MAINTAINER RealPage DevOps Foundation-Devops@RealPage.com
 LABEL version="1.0.0-beta" \
-	  com.realpage.php.version="7.0.4" \
-	  com.realpage.php.type="fpm"
+      com.realpage.php.version="7.0.4" \
+      com.realpage.php.type="fpm"
+
+WORKDIR /var/www
 
 # install extensions
 RUN apt-get update && apt-get install -y libmcrypt-dev libpq5 libpq-dev \
-	&& docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \
-	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && rm -r /var/www/html

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:7.0.4-fpm
+MAINTAINER RealPage DevOps Foundation-Devops@RealPage.com
+LABEL version="1.0.0-beta" \
+	  com.realpage.php.version="7.0.4" \
+	  com.realpage.php.type="fpm"
+
+# install extensions
+RUN apt-get update && apt-get install -y libmcrypt-dev libpq5 libpq-dev \
+	&& docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \
+	&& apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -7,5 +7,4 @@ LABEL version="1.0.0-beta" \
 # install extensions
 RUN apt-get update && apt-get install -y libmcrypt-dev libpq5 libpq-dev \
     && docker-php-ext-install mcrypt mbstring pgsql pdo_pgsql \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && rm -r /var/www/html
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# php
-RealPage Official Docker Image for PHP
+# RealPage Official Docker Image for PHP
+
+## Supported tags
+- [`7.0.4-cli`, `7.0-cli`, `7-cli`, `cli`, `7.0.4`, `7.0`, `7`, `latest` (*7.0/Dockerfile*)](https://github.com/realpage/php/tree/v1.0.0-beta/7.0/Dockerfile)
+- [`7.0.4-fpm`, `7.0-fpm`, `7-fpm`, `fpm` (*7.0/fpm/Dockerfile*)](https://github.com/realpage/php/tree/v1.0.0-beta/7.0/fpm/Dockerfile)
+
+## How this image is used
+This image is used alongside the official [Laravel](https://github.com/RealPage/laravel.git) and [Lumen](https://github.com/RealPage/laravel.git) starter projects. It comes packaged with the requirements for Laravel and Lumen to run along with any required Postgres extensions.
+
+## FAQs
+- We need an extension that isn't included in this image? How do I get an image with the extension I need?
+  - Hit us up at [RealPage-DevOps@RealPage.com](mailto:realpage-devops@realpage.com) with your information, requested extension, and reasoning, and we'll help figure out how to support your needs.
+
+## Issues
+If you have any problems with or questions about this image, please contact us through a [GitHub issue](https://github.com/realpage/php/issues).
+
+## License
+View [license information](http://php.net/license/) for the software contained in this image.
+
+## Supported Docker versions
+This image is officially supported on Docker version 1.10.3.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# RealPage Official Docker Image for PHP
+# RealPage Official Docker Image for PHP [![Build Status](https://travis-ci.org/Realpage/php.svg?branch=master)](https://travis-ci.org/Realpage/php)
+
 
 ## Supported tags
 - [`7.0.4-cli`, `7.0-cli`, `7-cli`, `cli`, `7.0.4`, `7.0`, `7`, `latest` (*7.0/Dockerfile*)](https://github.com/realpage/php/tree/v1.0.0-beta/7.0/Dockerfile)

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ tagsfpm=""
 
 echo "Building tags for cli images"
 for version in "${cli[@]}"; do
-	tagscli="${tagscli} -t ${repository}:${version}"
+  tagscli="${tagscli} -t ${repository}:${version}"
 done
 
 echo "Building base cli images"
@@ -16,7 +16,7 @@ docker build ${tagscli} -f 7.0/Dockerfile .
 
 echo "Building tags for fpm images"
 for version in "${fpm[@]}"; do
-	tagsfpm="${tagsfpm} -t ${repository}:${version}"
+  tagsfpm="${tagsfpm} -t ${repository}:${version}"
 done
 
 echo "Building base cli images"
@@ -24,9 +24,9 @@ docker build ${tagsfpm} -f 7.0/fpm/Dockerfile .
 
 echo "Pushing builds"
 for version in "${cli[@]}"; do
-	docker push ${repository}:${version}
+  docker push ${repository}:${version}
 done
 
 for version in "${fpm[@]}"; do
-	docker push ${repository}:${version}
+  docker push ${repository}:${version}
 done

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+repository="realpage/php"
+cli=( "7.0.4-cli" "7.0-cli" "7-cli" "cli" "7.0.4" "7.0" "7" "latest" )
+tagscli=""
+fpm=( "7.0.4-fpm" "7.0-fpm" "7-fpm" "fpm" )
+tagsfpm=""
+
+echo "Building tags for cli images"
+for version in "${cli[@]}"; do
+	tagscli="${tagscli} -t ${repository}:${version}"
+done
+
+echo "Building base cli images"
+docker build ${tagscli} -f 7.0/Dockerfile .
+
+echo "Building tags for fpm images"
+for version in "${fpm[@]}"; do
+	tagsfpm="${tagsfpm} -t ${repository}:${version}"
+done
+
+echo "Building base cli images"
+docker build ${tagsfpm} -f 7.0/fpm/Dockerfile .
+
+echo "Pushing builds"
+for version in "${cli[@]}"; do
+	docker push ${repository}:${version}
+done
+
+for version in "${fpm[@]}"; do
+	docker push ${repository}:${version}
+done


### PR DESCRIPTION
Some things to note about these images:
- Extending official image down to PATCH version specification.
- `MAINTAINER` is team specific, allowing all members to contribute. :facepunch: 
- `LABEL`s are provided to allow metadata lookups. This can be useful for infrastructure to make decisions about the purpose and requirements of specific containers.
- Dockerfile itself is versioned via metadata
- Single script build process to simplify and standardize tagging

Still needing:
- Cleaner `build.sh`
- Seriously more descriptive README
- Changelog?

---
Update:
- Leaving the `build.sh` as is for now
- README has been updated
- No changelog
- TravisCI integration has been added with tests against [docker/official-images](https://github.com/docker-library/official-images) repo